### PR TITLE
fix: add module exports for NLIChecker and AlignScoreChecker

### DIFF
--- a/refchecker/checker/__init__.py
+++ b/refchecker/checker/__init__.py
@@ -1,1 +1,3 @@
 from .llm_checker import LLMChecker
+from .nli_checker import NLIChecker
+from .alignscore.align_score_checker import AlignScoreChecker


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added appropriate module imports for `NLIChecker` and `AlignScoreChecker` in `refchecker/checker/__init__.py`. Previously, these classes were not importable, and broke existing dependencies such as [here in the `ragchecker` library](https://github.com/amazon-science/RAGChecker/blob/main/ragchecker/evaluator.py#L5-L7).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
